### PR TITLE
feat: add postgres restore script with safe input validation

### DIFF
--- a/scripts/restore-db.sh
+++ b/scripts/restore-db.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# scripts/restore.sh - Restore a PostgreSQL backup into the running stack
+# scripts/restore-db.sh - Restore a PostgreSQL backup into the running stack
 #
 # Usage:
-#   restore.sh              — interactive: list backups and prompt for choice
-#   restore.sh <file>       — non-interactive: restore a specific backup file
+#   restore-db.sh              — interactive: list backups and prompt for choice
+#   restore-db.sh <file>       — non-interactive: restore a specific backup file
 #
 # Environment variables (loaded from $DEPLOY_DIR/.env if present):
 #   DEPLOY_DIR      Base directory on the server (default: /home/deploy/iu-alumni)


### PR DESCRIPTION
## Summary

Adds `scripts/restore.sh` — an interactive PostgreSQL restore utility.

### Key validation fix
Instead of using `sed -n "${CHOICE}p"` (which silently returns empty string for out-of-range input), the script uses `mapfile` to load backups into an array and validates the choice before indexing:

```bash
if ! [[ "$CHOICE" =~ ^[0-9]+$ ]] || (( CHOICE < 1 || CHOICE > ${#BACKUPS[@]} )); then
    die "Invalid selection: $CHOICE (must be between 1 and ${#BACKUPS[@]})"
fi
```

This emits `Invalid selection: N` immediately rather than the confusing `File not found: ` that would result from an empty `BACKUP_FILE`.

### Features
- Interactive mode: lists `.sql.gz` backups from `$DEPLOY_DIR/data/backups` sorted newest-first, prompts for numeric selection
- Non-interactive mode: `restore.sh <file>` for scripted use
- Requires typing `yes` before dropping and recreating the database
- Finds the running Postgres container by stack service name automatically
