### PR TITLE
revert: remove bot deployment, restore mobile to mobile repo

### DIFF
--- a/nginx/mobile.conf.template
+++ b/nginx/mobile.conf.template
@@ -36,7 +36,7 @@ server {
 
     location / {
         set $upstream_mobile mobile;
-        proxy_pass http://$upstream_mobile:3000;
+        proxy_pass http://$upstream_mobile:80;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/terraform/github/environments.tf
+++ b/terraform/github/environments.tf
@@ -9,7 +9,6 @@ locals {
     backend  = "iu-alumni-backend"
     frontend = "iu-alumni-frontend"
     mobile   = "iu-alumni-mobile"
-    bot      = "iu-alumni-bot"
     infra    = "iu-alumni-infra"
   }
 }
@@ -243,18 +242,3 @@ resource "github_actions_environment_secret" "mobile_web_salt_production" {
   plaintext_value = var.production_web_salt
 }
 
-# ── Mobile WebView: MOBILE_URL — URL of the Nuxt web app loaded by the shell ──
-
-resource "github_actions_environment_variable" "mobile_url_testing" {
-  repository    = "iu-alumni-mobile"
-  environment   = github_repository_environment.testing["mobile"].environment
-  variable_name = "MOBILE_URL"
-  value         = "https://mobile.${var.testing_domain}"
-}
-
-resource "github_actions_environment_variable" "mobile_url_production" {
-  repository    = "iu-alumni-mobile"
-  environment   = github_repository_environment.production["mobile"].environment
-  variable_name = "MOBILE_URL"
-  value         = "https://mobile.${var.production_domain}"
-}

--- a/terraform/github/repos.tf
+++ b/terraform/github/repos.tf
@@ -7,7 +7,6 @@ locals {
     backend  = "iu-alumni-backend"
     frontend = "iu-alumni-frontend"
     mobile   = "iu-alumni-mobile"
-    bot      = "iu-alumni-bot"
     infra    = "iu-alumni-infra"
   }
 
@@ -17,8 +16,7 @@ locals {
   required_checks = {
     backend  = ["build-image", "deploy-testing / deploy"]
     frontend = ["build-image", "deploy-testing / deploy"]
-    mobile   = ["build-testing"]
-    bot      = ["build-testing", "deploy-testing / deploy"]
+    mobile   = ["build-testing", "deploy-testing / deploy"]
     infra    = ["deploy-testing / deploy"]
   }
 }
@@ -36,10 +34,6 @@ import {
 import {
   to = github_repository.repos["mobile"]
   id = "iu-alumni-mobile"
-}
-import {
-  to = github_repository.repos["bot"]
-  id = "iu-alumni-bot"
 }
 import {
   to = github_repository.repos["infra"]


### PR DESCRIPTION
## Changes

### `terraform/github/repos.tf`
- Remove `bot = "iu-alumni-bot"` from `repos` and `required_checks` locals
- Remove bot import block
- Restore mobile required checks to `["build-testing", "deploy-testing / deploy"]`

### `terraform/github/environments.tf`
- Remove `bot` from `app_repos` (stops provisioning GitHub environments + SSH secrets for bot repo)
- Remove `MOBILE_URL` environment variables that were added for the mobile WebView shell

### `nginx/mobile.conf.template`
- Revert proxy port `3000` → `80` (back to Flutter web app, not Nuxt Node.js server)

## Terraform state
All 10 bot-related resources have been removed from Terraform state (`terraform state rm`) so they are released without deleting the actual GitHub repository.