### PR TITLE
feat: migrate deploy jobs to self-hosted runner

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -44,7 +44,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux]
     environment: ${{ inputs.environment }}
     steps:
       - name: Deploy via SSH

--- a/.github/workflows/deploy-service.yml
+++ b/.github/workflows/deploy-service.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux]
     environment: ${{ inputs.environment }}
     steps:
       - name: Deploy via SSH

--- a/.github/workflows/setup-server.yml
+++ b/.github/workflows/setup-server.yml
@@ -61,7 +61,7 @@ jobs:
             -e "cors_origins=${{ secrets.CORS_ORIGINS }}" \
             -e "login_code_expiry_minutes=${{ secrets.LOGIN_CODE_EXPIRY_MINUTES }}" \
             -e "password_reset_expiry_minutes=${{ secrets.PASSWORD_RESET_EXPIRY_MINUTES }}" \
-            --private-key /home/deploy/.ssh/deploy_key
+            --private-key /home/deploy/.ssh/deploy
 
       - name: Bootstrap infrastructure (first deploy + SSL)
         uses: appleboy/ssh-action@v1
@@ -129,7 +129,7 @@ jobs:
             -e "cors_origins=${{ secrets.CORS_ORIGINS }}" \
             -e "login_code_expiry_minutes=${{ secrets.LOGIN_CODE_EXPIRY_MINUTES }}" \
             -e "password_reset_expiry_minutes=${{ secrets.PASSWORD_RESET_EXPIRY_MINUTES }}" \
-            --private-key /home/deploy/.ssh/deploy_key
+            --private-key /home/deploy/.ssh/deploy
 
       - name: Bootstrap infrastructure (first deploy + SSL)
         uses: appleboy/ssh-action@v1

--- a/.github/workflows/setup-server.yml
+++ b/.github/workflows/setup-server.yml
@@ -21,22 +21,10 @@ on:
 jobs:
   setup-testing:
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'testing'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux]
     environment: testing
     steps:
       - uses: actions/checkout@v6
-
-      - name: Install Ansible
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y ansible
-
-      - name: Write SSH key
-        run: |
-          mkdir -p ~/.ssh
-          printf '%s\n' "${{ secrets.SERVER_SSH_KEY }}" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -H "${{ secrets.SERVER_HOST }}" >> ~/.ssh/known_hosts 2>/dev/null || true
 
       - name: Run setup-server playbook
         working-directory: ansible
@@ -73,7 +61,7 @@ jobs:
             -e "cors_origins=${{ secrets.CORS_ORIGINS }}" \
             -e "login_code_expiry_minutes=${{ secrets.LOGIN_CODE_EXPIRY_MINUTES }}" \
             -e "password_reset_expiry_minutes=${{ secrets.PASSWORD_RESET_EXPIRY_MINUTES }}" \
-            --private-key ~/.ssh/deploy_key
+            --private-key /home/deploy/.ssh/deploy_key
 
       - name: Bootstrap infrastructure (first deploy + SSL)
         uses: appleboy/ssh-action@v1
@@ -101,22 +89,10 @@ jobs:
     if: >
       (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production') ||
       (github.event_name == 'push' && github.ref == 'refs/heads/main')
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux]
     environment: production
     steps:
       - uses: actions/checkout@v6
-
-      - name: Install Ansible
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y ansible
-
-      - name: Write SSH key
-        run: |
-          mkdir -p ~/.ssh
-          printf '%s\n' "${{ secrets.SERVER_SSH_KEY }}" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -H "${{ secrets.SERVER_HOST }}" >> ~/.ssh/known_hosts 2>/dev/null || true
 
       - name: Run setup-server playbook
         working-directory: ansible
@@ -153,7 +129,7 @@ jobs:
             -e "cors_origins=${{ secrets.CORS_ORIGINS }}" \
             -e "login_code_expiry_minutes=${{ secrets.LOGIN_CODE_EXPIRY_MINUTES }}" \
             -e "password_reset_expiry_minutes=${{ secrets.PASSWORD_RESET_EXPIRY_MINUTES }}" \
-            --private-key ~/.ssh/deploy_key
+            --private-key /home/deploy/.ssh/deploy_key
 
       - name: Bootstrap infrastructure (first deploy + SSL)
         uses: appleboy/ssh-action@v1

--- a/.github/workflows/update-env.yml
+++ b/.github/workflows/update-env.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Write SSH key
         run: |
           mkdir -p ~/.ssh
-          printf '%s\n' "${{ secrets.SERVER_SSH_KEY }}" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
+          printf '%s\n' "${{ secrets.SERVER_SSH_KEY }}" > ~/.ssh/deploy
+          chmod 600 ~/.ssh/deploy
           ssh-keyscan -H "${{ secrets.SERVER_HOST }}" >> ~/.ssh/known_hosts 2>/dev/null || true
 
       - name: Write .env on server
@@ -67,7 +67,7 @@ jobs:
             -e "cors_origins=${{ secrets.CORS_ORIGINS }}" \
             -e "login_code_expiry_minutes=${{ secrets.LOGIN_CODE_EXPIRY_MINUTES }}" \
             -e "password_reset_expiry_minutes=${{ secrets.PASSWORD_RESET_EXPIRY_MINUTES }}" \
-            --private-key ~/.ssh/deploy_key
+            --private-key ~/.ssh/deploy
 
   update-env-production:
     if: github.event.inputs.environment == 'production'
@@ -84,8 +84,8 @@ jobs:
       - name: Write SSH key
         run: |
           mkdir -p ~/.ssh
-          printf '%s\n' "${{ secrets.SERVER_SSH_KEY }}" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
+          printf '%s\n' "${{ secrets.SERVER_SSH_KEY }}" > ~/.ssh/deploy
+          chmod 600 ~/.ssh/deploy
           ssh-keyscan -H "${{ secrets.SERVER_HOST }}" >> ~/.ssh/known_hosts 2>/dev/null || true
 
       - name: Write .env on server
@@ -124,4 +124,4 @@ jobs:
             -e "cors_origins=${{ secrets.CORS_ORIGINS }}" \
             -e "login_code_expiry_minutes=${{ secrets.LOGIN_CODE_EXPIRY_MINUTES }}" \
             -e "password_reset_expiry_minutes=${{ secrets.PASSWORD_RESET_EXPIRY_MINUTES }}" \
-            --private-key ~/.ssh/deploy_key
+            --private-key ~/.ssh/deploy


### PR DESCRIPTION
Switch all deployment jobs to run-on [self-hosted, linux] so the runner can SSH to VMs over the internal university network, where no public inbound SSH is reachable. Remove Install Ansible and Write SSH key steps from setup-server.yml since Ansible is pre-installed and the SSH key is persistent on the runner at /home/deploy/.ssh/deploy_key.

## Description

<!-- Describe your changes clearly. Include motivation and context. -->

Closes #

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] ♻️  Refactoring (no functional changes)
- [ ] 📝 Documentation update
- [ ] 🔧 CI / configuration

## How Has This Been Tested?

<!-- Describe what you tested and how to verify the change. -->

## Checklist

- [ ] Self-review completed
- [ ] Code follows existing style guidelines
- [ ] Tests added / updated where applicable
- [ ] All existing tests pass
- [ ] Documentation updated where applicable
- [ ] YAML/shell lint passes (`ci.yml` workflow)
- [ ] `docker-compose` / stack changes validated locally
- [ ] Ansible changes are idempotent
- [ ] Terraform plan reviewed if `terraform/` changed
- [ ] No secrets or credentials committed
