### PR TITLE
ci: bootstrap self-hosted runner tools in deploy workflows

### DIFF
--- a/.github/actions/bootstrap-self-hosted-tools/action.yml
+++ b/.github/actions/bootstrap-self-hosted-tools/action.yml
@@ -1,0 +1,17 @@
+name: Bootstrap self-hosted runner tools
+description: Install required packages used by deployment/setup workflows
+
+runs:
+  using: composite
+  steps:
+    - name: Install tools
+      shell: bash
+      run: |
+        set -euo pipefail
+        sudo apt-get update
+        sudo apt-get install -y ansible docker.io openssh-client git
+        if command -v systemctl >/dev/null 2>&1; then
+          sudo systemctl start docker
+        fi
+        ansible-playbook --version
+        docker --version

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -47,6 +47,17 @@ jobs:
     runs-on: [self-hosted]
     environment: ${{ inputs.environment }}
     steps:
+      - name: Install self-hosted runner tools
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y ansible docker.io openssh-client git
+          if command -v systemctl >/dev/null 2>&1; then
+            sudo systemctl start docker
+          fi
+          ansible-playbook --version
+          docker --version
+
       - name: Deploy via SSH
         uses: appleboy/ssh-action@v1
         with:

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -47,16 +47,10 @@ jobs:
     runs-on: [self-hosted]
     environment: ${{ inputs.environment }}
     steps:
+      - uses: actions/checkout@v6
+
       - name: Install self-hosted runner tools
-        run: |
-          set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y ansible docker.io openssh-client git
-          if command -v systemctl >/dev/null 2>&1; then
-            sudo systemctl start docker
-          fi
-          ansible-playbook --version
-          docker --version
+        uses: ./.github/actions/bootstrap-self-hosted-tools
 
       - name: Deploy via SSH
         uses: appleboy/ssh-action@v1

--- a/.github/workflows/deploy-service.yml
+++ b/.github/workflows/deploy-service.yml
@@ -33,6 +33,17 @@ jobs:
     runs-on: [self-hosted]
     environment: ${{ inputs.environment }}
     steps:
+      - name: Install self-hosted runner tools
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y ansible docker.io openssh-client git
+          if command -v systemctl >/dev/null 2>&1; then
+            sudo systemctl start docker
+          fi
+          ansible-playbook --version
+          docker --version
+
       - name: Deploy via SSH
         uses: appleboy/ssh-action@v1
         with:

--- a/.github/workflows/deploy-service.yml
+++ b/.github/workflows/deploy-service.yml
@@ -33,16 +33,10 @@ jobs:
     runs-on: [self-hosted]
     environment: ${{ inputs.environment }}
     steps:
+      - uses: actions/checkout@v6
+
       - name: Install self-hosted runner tools
-        run: |
-          set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y ansible docker.io openssh-client git
-          if command -v systemctl >/dev/null 2>&1; then
-            sudo systemctl start docker
-          fi
-          ansible-playbook --version
-          docker --version
+        uses: ./.github/actions/bootstrap-self-hosted-tools
 
       - name: Deploy via SSH
         uses: appleboy/ssh-action@v1

--- a/.github/workflows/setup-server.yml
+++ b/.github/workflows/setup-server.yml
@@ -26,6 +26,17 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Install self-hosted runner tools
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y ansible docker.io openssh-client git
+          if command -v systemctl >/dev/null 2>&1; then
+            sudo systemctl start docker
+          fi
+          ansible-playbook --version
+          docker --version
+
       - name: Run setup-server playbook
         working-directory: ansible
         env:
@@ -92,6 +103,17 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@v6
+
+      - name: Install self-hosted runner tools
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y ansible docker.io openssh-client git
+          if command -v systemctl >/dev/null 2>&1; then
+            sudo systemctl start docker
+          fi
+          ansible-playbook --version
+          docker --version
 
       - name: Run setup-server playbook
         working-directory: ansible

--- a/.github/workflows/setup-server.yml
+++ b/.github/workflows/setup-server.yml
@@ -27,15 +27,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install self-hosted runner tools
-        run: |
-          set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y ansible docker.io openssh-client git
-          if command -v systemctl >/dev/null 2>&1; then
-            sudo systemctl start docker
-          fi
-          ansible-playbook --version
-          docker --version
+        uses: ./.github/actions/bootstrap-self-hosted-tools
 
       - name: Run setup-server playbook
         working-directory: ansible
@@ -105,15 +97,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install self-hosted runner tools
-        run: |
-          set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y ansible docker.io openssh-client git
-          if command -v systemctl >/dev/null 2>&1; then
-            sudo systemctl start docker
-          fi
-          ansible-playbook --version
-          docker --version
+        uses: ./.github/actions/bootstrap-self-hosted-tools
 
       - name: Run setup-server playbook
         working-directory: ansible


### PR DESCRIPTION
## Summary\n- add a bootstrap step in all self-hosted deployment jobs\n- install required runner tools before commands/actions execute: ansible, docker, openssh-client, and git\n- start docker service when systemd is available and print tool versions\n\n## Why\nSelf-hosted runners may not have these dependencies preinstalled, causing deploy/setup workflows to fail before command execution.