### PR TITLE
ci: make self-hosted bootstrap non-interactive

### DIFF
--- a/.github/actions/bootstrap-self-hosted-tools/action.yml
+++ b/.github/actions/bootstrap-self-hosted-tools/action.yml
@@ -8,10 +8,24 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        sudo apt-get update
-        sudo apt-get install -y ansible docker.io openssh-client git
+
+        SUDO=""
+        if command -v sudo >/dev/null 2>&1; then
+          if sudo -n true >/dev/null 2>&1; then
+            SUDO="sudo -n"
+          elif [ "$(id -u)" -ne 0 ]; then
+            echo "Runner user must be root or have passwordless sudo for apt installs." >&2
+            exit 1
+          fi
+        elif [ "$(id -u)" -ne 0 ]; then
+          echo "sudo is not available and runner user is not root; cannot install packages." >&2
+          exit 1
+        fi
+
+        $SUDO apt-get update
+        $SUDO apt-get install -y ansible docker.io docker-compose-plugin openssh-client git
         if command -v systemctl >/dev/null 2>&1; then
-          sudo systemctl start docker
+          $SUDO systemctl start docker || true
         fi
         ansible-playbook --version
         docker --version


### PR DESCRIPTION
## Summary
- update the shared self-hosted bootstrap action to avoid interactive sudo prompts
- use passwordless sudo when available, otherwise run directly as root
- fail with a clear message if package installation cannot run with privileges
- include docker-compose-plugin installation

## Context
This fixes self-hosted runner failures where sudo requires an interactive password prompt.