### PR TITLE
Fix Ansible sudo usage for zsh setup tasks

### DIFF
--- a/ansible/playbooks/setup-server.yml
+++ b/ansible/playbooks/setup-server.yml
@@ -114,16 +114,14 @@
 
     # ── Zsh + Oh My Zsh ─────────────────────────────────
     - name: Install Oh My Zsh for deploy user
-      become: true
-      become_user: "{{ ansible_user }}"
+      become: false
       ansible.builtin.shell: |
         sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
       args:
         creates: "/home/{{ ansible_user }}/.oh-my-zsh"
 
     - name: Clone Zsh plugins
-      become: true
-      become_user: "{{ ansible_user }}"
+      become: false
       ansible.builtin.git:
         repo: "{{ item.repo }}"
         dest: "/home/{{ ansible_user }}/.oh-my-zsh/custom/plugins/{{ item.name }}"
@@ -131,8 +129,7 @@
       loop: "{{ zsh_plugins }}"
 
     - name: Configure zshrc
-      become: true
-      become_user: "{{ ansible_user }}"
+      become: false
       ansible.builtin.template:
         src: zshrc.j2
         dest: "/home/{{ ansible_user }}/.zshrc"


### PR DESCRIPTION
Summary:
- remove become+become_user from user-level zsh setup tasks
- run Oh My Zsh install, plugin clone, and zshrc templating as the SSH user
- prevent non-interactive sudo escalation failures in workflow runs

Why:
Global become is enabled, but these tasks target the deploy user home and should run as that user directly.

Changed files:
- ansible/playbooks/setup-server.yml