### PR TITLE
chore: disable internal nginx TLS bootstrap

### DIFF
--- a/nginx/api.conf.template
+++ b/nginx/api.conf.template
@@ -6,36 +6,14 @@
 server {
     listen 80;
     server_name api.${DOMAIN};
+    # TLS is terminated by the cloud-provider Nginx.
+    # Keep app Nginx on HTTP only for upstream routing.
+    resolver 127.0.0.11 valid=10s ipv6=off;
+    resolver_timeout 5s;
 
     location /.well-known/acme-challenge/ {
         root /var/www/certbot;
     }
-
-    location / {
-        return 301 https://$host$request_uri;
-    }
-}
-
-server {
-    listen 443 ssl;
-    http2 on;
-    server_name api.${DOMAIN};
-
-    ssl_certificate /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}/privkey.pem;
-    ssl_protocols TLSv1.2 TLSv1.3;
-    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
-    ssl_prefer_server_ciphers off;
-    ssl_session_cache shared:SSL:10m;
-    ssl_session_timeout 1d;
-
-    resolver 127.0.0.11 valid=10s ipv6=off;
-    resolver_timeout 5s;
-
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-
-    client_max_body_size 50M;
 
     location / {
         set $upstream_backend backend;
@@ -47,3 +25,35 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 }
+
+# server {
+#     listen 443 ssl;
+#     http2 on;
+#     server_name api.${DOMAIN};
+#
+#     ssl_certificate /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
+#     ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}/privkey.pem;
+#     ssl_protocols TLSv1.2 TLSv1.3;
+#     ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+#     ssl_prefer_server_ciphers off;
+#     ssl_session_cache shared:SSL:10m;
+#     ssl_session_timeout 1d;
+#
+#     resolver 127.0.0.11 valid=10s ipv6=off;
+#     resolver_timeout 5s;
+#
+#     add_header X-Content-Type-Options "nosniff" always;
+#     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+#
+#     client_max_body_size 50M;
+#
+#     location / {
+#         set $upstream_backend backend;
+#         proxy_pass http://$upstream_backend:8080;
+#         proxy_http_version 1.1;
+#         proxy_set_header Host $host;
+#         proxy_set_header X-Real-IP $remote_addr;
+#         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#         proxy_set_header X-Forwarded-Proto $scheme;
+#     }
+# }

--- a/nginx/app.conf.template
+++ b/nginx/app.conf.template
@@ -5,38 +5,14 @@
 server {
     listen 80;
     server_name ${DOMAIN} admin.${DOMAIN};
+    # TLS is terminated by the cloud-provider Nginx.
+    # Keep app Nginx on HTTP only for upstream routing.
+    resolver 127.0.0.11 valid=10s ipv6=off;
+    resolver_timeout 5s;
 
     location /.well-known/acme-challenge/ {
         root /var/www/certbot;
     }
-
-    location / {
-        return 301 https://$host$request_uri;
-    }
-}
-
-server {
-    listen 443 ssl;
-    http2 on;
-    server_name ${DOMAIN} admin.${DOMAIN};
-
-    ssl_certificate /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}/privkey.pem;
-    ssl_protocols TLSv1.2 TLSv1.3;
-    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
-    ssl_prefer_server_ciphers off;
-    ssl_session_cache shared:SSL:10m;
-    ssl_session_timeout 1d;
-
-    resolver 127.0.0.11 valid=10s ipv6=off;
-    resolver_timeout 5s;
-
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header X-XSS-Protection "1; mode=block" always;
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-
-    client_max_body_size 10M;
 
     location / {
         set $upstream_frontend frontend;
@@ -50,3 +26,39 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 }
+
+# server {
+#     listen 443 ssl;
+#     http2 on;
+#     server_name ${DOMAIN} admin.${DOMAIN};
+#
+#     ssl_certificate /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
+#     ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}/privkey.pem;
+#     ssl_protocols TLSv1.2 TLSv1.3;
+#     ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+#     ssl_prefer_server_ciphers off;
+#     ssl_session_cache shared:SSL:10m;
+#     ssl_session_timeout 1d;
+#
+#     resolver 127.0.0.11 valid=10s ipv6=off;
+#     resolver_timeout 5s;
+#
+#     add_header X-Frame-Options "SAMEORIGIN" always;
+#     add_header X-Content-Type-Options "nosniff" always;
+#     add_header X-XSS-Protection "1; mode=block" always;
+#     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+#
+#     client_max_body_size 10M;
+#
+#     location / {
+#         set $upstream_frontend frontend;
+#         proxy_pass http://$upstream_frontend:3000;
+#         proxy_http_version 1.1;
+#         proxy_set_header Upgrade $http_upgrade;
+#         proxy_set_header Connection "upgrade";
+#         proxy_set_header Host $host;
+#         proxy_set_header X-Real-IP $remote_addr;
+#         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#         proxy_set_header X-Forwarded-Proto $scheme;
+#     }
+# }

--- a/nginx/grafana.conf.template
+++ b/nginx/grafana.conf.template
@@ -5,31 +5,14 @@
 server {
     listen 80;
     server_name grafana.${DOMAIN};
+    # TLS is terminated by the cloud-provider Nginx.
+    # Keep app Nginx on HTTP only for upstream routing.
+    resolver 127.0.0.11 valid=10s ipv6=off;
+    resolver_timeout 5s;
 
     location /.well-known/acme-challenge/ {
         root /var/www/certbot;
     }
-
-    location / {
-        return 301 https://$host$request_uri;
-    }
-}
-
-server {
-    listen 443 ssl;
-    http2 on;
-    server_name grafana.${DOMAIN};
-
-    ssl_certificate /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}/privkey.pem;
-    ssl_protocols TLSv1.2 TLSv1.3;
-    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
-    ssl_prefer_server_ciphers off;
-    ssl_session_cache shared:SSL:10m;
-    ssl_session_timeout 1d;
-
-    resolver 127.0.0.11 valid=10s ipv6=off;
-    resolver_timeout 5s;
 
     location / {
         set $upstream_grafana grafana;
@@ -43,3 +26,32 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 }
+
+# server {
+#     listen 443 ssl;
+#     http2 on;
+#     server_name grafana.${DOMAIN};
+#
+#     ssl_certificate /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
+#     ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}/privkey.pem;
+#     ssl_protocols TLSv1.2 TLSv1.3;
+#     ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+#     ssl_prefer_server_ciphers off;
+#     ssl_session_cache shared:SSL:10m;
+#     ssl_session_timeout 1d;
+#
+#     resolver 127.0.0.11 valid=10s ipv6=off;
+#     resolver_timeout 5s;
+#
+#     location / {
+#         set $upstream_grafana grafana;
+#         proxy_pass http://$upstream_grafana:3000;
+#         proxy_http_version 1.1;
+#         proxy_set_header Upgrade $http_upgrade;
+#         proxy_set_header Connection "upgrade";
+#         proxy_set_header Host $host;
+#         proxy_set_header X-Real-IP $remote_addr;
+#         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#         proxy_set_header X-Forwarded-Proto $scheme;
+#     }
+# }

--- a/nginx/mobile.conf.template
+++ b/nginx/mobile.conf.template
@@ -5,34 +5,14 @@
 server {
     listen 80;
     server_name mobile.${DOMAIN};
+    # TLS is terminated by the cloud-provider Nginx.
+    # Keep app Nginx on HTTP only for upstream routing.
+    resolver 127.0.0.11 valid=10s ipv6=off;
+    resolver_timeout 5s;
 
     location /.well-known/acme-challenge/ {
         root /var/www/certbot;
     }
-
-    location / {
-        return 301 https://$host$request_uri;
-    }
-}
-
-server {
-    listen 443 ssl;
-    http2 on;
-    server_name mobile.${DOMAIN};
-
-    ssl_certificate /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}/privkey.pem;
-    ssl_protocols TLSv1.2 TLSv1.3;
-    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
-    ssl_prefer_server_ciphers off;
-    ssl_session_cache shared:SSL:10m;
-    ssl_session_timeout 1d;
-
-    resolver 127.0.0.11 valid=10s ipv6=off;
-    resolver_timeout 5s;
-
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-Content-Type-Options "nosniff" always;
 
     location / {
         set $upstream_mobile mobile;
@@ -44,3 +24,33 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 }
+
+# server {
+#     listen 443 ssl;
+#     http2 on;
+#     server_name mobile.${DOMAIN};
+#
+#     ssl_certificate /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
+#     ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}/privkey.pem;
+#     ssl_protocols TLSv1.2 TLSv1.3;
+#     ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+#     ssl_prefer_server_ciphers off;
+#     ssl_session_cache shared:SSL:10m;
+#     ssl_session_timeout 1d;
+#
+#     resolver 127.0.0.11 valid=10s ipv6=off;
+#     resolver_timeout 5s;
+#
+#     add_header X-Frame-Options "SAMEORIGIN" always;
+#     add_header X-Content-Type-Options "nosniff" always;
+#
+#     location / {
+#         set $upstream_mobile mobile;
+#         proxy_pass http://$upstream_mobile:80;
+#         proxy_http_version 1.1;
+#         proxy_set_header Host $host;
+#         proxy_set_header X-Real-IP $remote_addr;
+#         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#         proxy_set_header X-Forwarded-Proto $scheme;
+#     }
+# }

--- a/nginx/portainer.conf.template
+++ b/nginx/portainer.conf.template
@@ -5,31 +5,14 @@
 server {
     listen 80;
     server_name portainer.${DOMAIN};
+    # TLS is terminated by the cloud-provider Nginx.
+    # Keep app Nginx on HTTP only for upstream routing.
+    resolver 127.0.0.11 valid=10s ipv6=off;
+    resolver_timeout 5s;
 
     location /.well-known/acme-challenge/ {
         root /var/www/certbot;
     }
-
-    location / {
-        return 301 https://$host$request_uri;
-    }
-}
-
-server {
-    listen 443 ssl;
-    http2 on;
-    server_name portainer.${DOMAIN};
-
-    ssl_certificate /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}/privkey.pem;
-    ssl_protocols TLSv1.2 TLSv1.3;
-    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
-    ssl_prefer_server_ciphers off;
-    ssl_session_cache shared:SSL:10m;
-    ssl_session_timeout 1d;
-
-    resolver 127.0.0.11 valid=10s ipv6=off;
-    resolver_timeout 5s;
 
     location / {
         set $upstream_portainer portainer;
@@ -43,3 +26,32 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 }
+
+# server {
+#     listen 443 ssl;
+#     http2 on;
+#     server_name portainer.${DOMAIN};
+#
+#     ssl_certificate /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
+#     ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}/privkey.pem;
+#     ssl_protocols TLSv1.2 TLSv1.3;
+#     ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+#     ssl_prefer_server_ciphers off;
+#     ssl_session_cache shared:SSL:10m;
+#     ssl_session_timeout 1d;
+#
+#     resolver 127.0.0.11 valid=10s ipv6=off;
+#     resolver_timeout 5s;
+#
+#     location / {
+#         set $upstream_portainer portainer;
+#         proxy_pass http://$upstream_portainer:9000;
+#         proxy_http_version 1.1;
+#         proxy_set_header Upgrade $http_upgrade;
+#         proxy_set_header Connection "upgrade";
+#         proxy_set_header Host $host;
+#         proxy_set_header X-Real-IP $remote_addr;
+#         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#         proxy_set_header X-Forwarded-Proto $scheme;
+#     }
+# }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -108,12 +108,15 @@ init_ssl() {
 deploy() {
     ensure_network
 
-    if [ ! -d "$CERT_DIR" ]; then
-        log "No SSL certificates found — running SSL init first..."
-        init_ssl
-    else
-        generate_nginx_config
-    fi
+    # SSL bootstrap is disabled for now because TLS is terminated
+    # by cloud-provider Nginx before traffic reaches this stack.
+    # if [ ! -d "$CERT_DIR" ]; then
+    #     log "No SSL certificates found — running SSL init first..."
+    #     init_ssl
+    # else
+    #     generate_nginx_config
+    # fi
+    generate_nginx_config
 
     # Deploy (or update) the full infrastructure stack
     DEPLOY_DIR="$DEPLOY_DIR" docker stack deploy \

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -30,7 +30,6 @@ CERTBOT_EMAIL="${CERTBOT_EMAIL:-devops@${DOMAIN}}"
 NGINX_CONF_DIR="$DEPLOY_DIR/nginx/conf.d"
 CERTBOT_CONF_DIR="$DEPLOY_DIR/nginx/certbot/conf"
 CERTBOT_WWW_DIR="$DEPLOY_DIR/nginx/certbot/www"
-CERT_DIR="$CERTBOT_CONF_DIR/live/$DOMAIN"
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"; }
 


### PR DESCRIPTION
Summary:
- comment out internal listen 443 ssl server blocks in infra nginx templates
- route HTTP traffic directly to upstream services on port 80
- comment out SSL bootstrap check in scripts/deploy.sh and always generate nginx configs

Context:
TLS termination is handled by cloud-provider Nginx, so internal certbot and HTTPS bootstrap is temporarily disabled.