### PR TITLE
[codex] Harden backend mail env deploy

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -62,6 +62,19 @@ jobs:
             # Load shared env (domain, DB creds, secrets, etc.)
             if [ -f "$DEPLOY_DIR/.env" ]; then set -a && . "$DEPLOY_DIR/.env" && set +a; fi
 
+            if [ "${{ inputs.repo_name }}" = "iu-alumni-backend" ]; then
+              missing=""
+              for var in MAIL_USERNAME MAIL_PASSWORD MAIL_FROM MAIL_SERVER MAIL_PORT; do
+                eval "value=\${$var:-}"
+                if [ -z "$value" ]; then missing="$missing $var"; fi
+              done
+              if [ -n "$missing" ]; then
+                echo "::error::Missing backend mail environment variables:$missing"
+                echo "Run the iu-alumni-infra setup-server or update-env workflow after configuring SMTP secrets."
+                exit 1
+              fi
+            fi
+
             REPO_DIR="$DEPLOY_DIR/${{ inputs.repo_name }}"
             REPO_URL="https://github.com/${{ github.repository }}.git"
 

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -65,7 +65,7 @@ jobs:
             if [ "${{ inputs.repo_name }}" = "iu-alumni-backend" ]; then
               missing=""
               for var in MAIL_USERNAME MAIL_PASSWORD MAIL_FROM MAIL_SERVER MAIL_PORT; do
-                eval "value=\${$var:-}"
+                value="$(printenv "$var" 2>/dev/null || true)"
                 if [ -z "$value" ]; then missing="$missing $var"; fi
               done
               if [ -n "$missing" ]; then

--- a/README.md
+++ b/README.md
@@ -164,6 +164,11 @@ Written to the server's `.env` by Ansible — no manual file editing needed.
 | -------------- | ------------------------------------------------------------------------------ |
 | `API_BASE_URL` | Full API URL baked into Flutter binary (e.g. `https://api.alumni.example.com`) |
 
+Mail secrets are rendered into the server `.env` and then shell-sourced during app deploys.
+Store SMTP passwords exactly as issued by the provider, including spaces in Gmail app
+passwords; the setup workflow quotes these values safely. After changing any mail secret,
+re-run `Update Environment` or `Setup Server`, then redeploy the backend.
+
 ---
 
 ## Local Development

--- a/ansible/playbooks/templates/env.j2
+++ b/ansible/playbooks/templates/env.j2
@@ -4,40 +4,40 @@
 # ────────────────────────────────────────────────────────────────
 
 # Deployment
-DEPLOY_DIR={{ deploy_dir }}
-DOMAIN={{ domain }}
-CERTBOT_EMAIL={{ certbot_email }}
+DEPLOY_DIR={{ deploy_dir | quote }}
+DOMAIN={{ domain | quote }}
+CERTBOT_EMAIL={{ certbot_email | quote }}
 SETUP_CERTIFICATES={{ setup_certificates | default(false) | bool | ternary('true', 'false') }}
 
 # PostgreSQL
-POSTGRES_USER={{ postgres_user }}
-POSTGRES_PASSWORD={{ postgres_password }}
-POSTGRES_DB={{ postgres_db }}
+POSTGRES_USER={{ postgres_user | quote }}
+POSTGRES_PASSWORD={{ postgres_password | quote }}
+POSTGRES_DB={{ postgres_db | quote }}
 
 # Backend
-SECRET_KEY={{ secret_key }}
-ADMIN_EMAIL={{ admin_email }}
-ADMIN_PASSWORD={{ admin_password }}
-EMAIL_HASH_SECRET={{ email_hash_secret }}
-CORS_ORIGINS={{ cors_origins }}
-ENVIRONMENT={{ app_environment }}
+SECRET_KEY={{ secret_key | quote }}
+ADMIN_EMAIL={{ admin_email | quote }}
+ADMIN_PASSWORD={{ admin_password | quote }}
+EMAIL_HASH_SECRET={{ email_hash_secret | quote }}
+CORS_ORIGINS={{ cors_origins | quote }}
+ENVIRONMENT={{ app_environment | quote }}
 
 LOGIN_CODE_EXPIRY_MINUTES={{ login_code_expiry_minutes }}
 PASSWORD_RESET_EXPIRY_MINUTES={{ password_reset_expiry_minutes }}
 
 # Mail
-MAIL_USERNAME={{ mail_username }}
-MAIL_PASSWORD={{ mail_password }}
-MAIL_FROM={{ mail_from }}
-MAIL_FROM_NAME={{ mail_from_name }}
-MAIL_SERVER={{ mail_server }}
-MAIL_PORT={{ mail_port }}
+MAIL_USERNAME={{ mail_username | quote }}
+MAIL_PASSWORD={{ mail_password | quote }}
+MAIL_FROM={{ mail_from | quote }}
+MAIL_FROM_NAME={{ mail_from_name | quote }}
+MAIL_SERVER={{ mail_server | quote }}
+MAIL_PORT={{ mail_port | quote }}
 
 # Telegram
-TELEGRAM_TOKEN={{ telegram_token }}
-ADMIN_CHAT_ID={{ admin_chat_id }}
-MINI_APP_URL={{ mini_app_url }}
+TELEGRAM_TOKEN={{ telegram_token | quote }}
+ADMIN_CHAT_ID={{ admin_chat_id | quote }}
+MINI_APP_URL={{ mini_app_url | quote }}
 
 # Grafana
-GRAFANA_USER={{ grafana_user }}
-GRAFANA_PASSWORD={{ grafana_password }}
+GRAFANA_USER={{ grafana_user | quote }}
+GRAFANA_PASSWORD={{ grafana_password | quote }}


### PR DESCRIPTION
## Summary
- quote generated server .env values so shell-sourced secrets with spaces or shell characters survive deploys
- add a backend deploy preflight for required SMTP variables
- document the mail-secret refresh and backend redeploy step

## Why
Production OTP email delivery depends on SMTP variables from the infra-managed .env. Gmail app passwords and display names can contain spaces, and the deployment scripts shell-source this file before deploying backend. Quoting the rendered values and failing fast on missing SMTP env makes the OTP failure mode visible and prevents a backend deploy with empty mail settings.

Fixes #61

## Validation
- ruby YAML parse for .github/workflows/deploy-app.yml
- bash -n scripts/deploy.sh
- shell-source simulation for spaced MAIL_PASSWORD and MAIL_FROM_NAME
- git diff --check

## Post-merge note
After merge, run the infra Update Environment or Setup Server workflow for production, then redeploy the backend so the running backend service receives the refreshed mail environment.