### PR TITLE
ci: encrypted secret-recovery workflow (rebuild lost tfvars)

### DIFF
--- a/.github/workflows/recover-secrets.yml
+++ b/.github/workflows/recover-secrets.yml
@@ -1,0 +1,84 @@
+name: Recover secrets (encrypted)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# One-off recovery aid. Dumps THIS repo's environment secrets, encrypts them
+# with an age PUBLIC key you provide at run time, and uploads ONLY the encrypted
+# blob as an artifact. Use it to rebuild terraform.tfvars after a lost state.
+#
+# Safety properties (these repos are PUBLIC, so logs + artifacts are world-readable):
+#   • Plaintext is NEVER printed. Secrets are passed via a step `env:` var and
+#     written to a file with `printf` — never echoed, and `set -x` is not used.
+#   • The artifact is encrypted to your age public key. Even though anyone can
+#     download it, only your PRIVATE key can decrypt it.
+#   • The age recipient is a PUBLIC key, so it is safe to paste as an input and
+#     safe for it to appear in logs.
+#
+# Usage:
+#   1. Locally:  age-keygen -o key.txt    (prints your public key: age1....)
+#   2. Actions ▸ this workflow ▸ Run workflow ▸ pick environment ▸ paste age1... key
+#   3. Download the artifact, then:  age -d -i key.txt secrets-<env>.json.age
+#
+# NOTE: reading `production` secrets requires running from a protected branch
+# (main) and approving any environment protection rules.
+# DELETE this workflow once recovery is complete.
+# ─────────────────────────────────────────────────────────────────────────────
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Environment to dump"
+        required: true
+        type: choice
+        options:
+          - testing
+          - production
+      age_recipient:
+        description: "Your age PUBLIC key (age1...). Not a secret — safe to paste."
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  dump:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    steps:
+      - name: Install age
+        run: |
+          set -euo pipefail
+          if ! command -v age >/dev/null 2>&1; then
+            sudo apt-get update -qq && sudo apt-get install -y -qq age || {
+              curl -fsSL https://github.com/FiloSottile/age/releases/download/v1.2.1/age-v1.2.1-linux-amd64.tar.gz | tar -xz
+              sudo install age/age /usr/local/bin/age
+            }
+          fi
+          age --version
+
+      - name: Dump and encrypt secrets
+        env:
+          # toJSON(secrets) includes this environment's secrets. Passed via env
+          # (not the run body) so the value is never rendered into the log.
+          ALL_SECRETS: ${{ toJSON(secrets) }}
+          RECIPIENT: ${{ inputs.age_recipient }}
+          ENV_NAME: ${{ inputs.environment }}
+        run: |
+          set -euo pipefail
+          # Write raw JSON to a file WITHOUT echoing it (printf shows only the
+          # literal command in the log, never the expanded value).
+          printf '%s' "$ALL_SECRETS" > secrets.json
+          # Encrypt to your public key. Only your private key can open this.
+          age -r "$RECIPIENT" -o "secrets-${ENV_NAME}.json.age" secrets.json
+          # Remove the plaintext from the runner.
+          shred -u secrets.json 2>/dev/null || rm -f secrets.json
+          echo "Wrote encrypted secrets-${ENV_NAME}.json.age ($(wc -c < "secrets-${ENV_NAME}.json.age") bytes)"
+
+      - name: Upload encrypted artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: secrets-${{ inputs.environment }}-age
+          path: secrets-*.json.age
+          retention-days: 1
+          if-no-files-found: error


### PR DESCRIPTION
## What
One-off, manually-triggered workflow to recover the environment secret **values** into an encrypted artifact — so we can rebuild the lost `terraform/github/terraform.tfvars` (Terraform state for the GitHub config was lost; structural resources were re-imported, but Actions secrets are write-only and can't be read back via the API/Terraform).

## Why it's safe on a public repo
These repos are public, so logs and artifacts are world-readable. This workflow is built around that:
- **No plaintext in logs** — `toJSON(secrets)` is passed via a step `env:` var and written to a file with `printf`; it is never echoed and `set -x` is not used.
- **Encrypted output only** — the dump is encrypted with an **age public key you supply at run time** (a public key is not sensitive). Only your private key can decrypt it.
- **Artifact retention: 1 day**, `contents: read` only, no `checkout`.

## How to use
1. Local: `age-keygen -o key.txt` (prints your `age1...` public key)
2. Actions ▸ **Recover secrets (encrypted)** ▸ Run workflow ▸ choose environment ▸ paste the `age1...` key
3. Download artifact, then `age -d -i key.txt secrets-<env>.json.age`

Run for **testing** and **production** separately. Production must run from `main` and may require environment approval.

## After recovery
**Delete this workflow** — it exists only to rebuild the tfvars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)