### PR TITLE
ci: fix update-env runner (private IPs) + add read-only diagnose workflow

### DIFF
--- a/.github/workflows/diagnose.yml
+++ b/.github/workflows/diagnose.yml
@@ -1,0 +1,115 @@
+name: Diagnose server
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Read-only diagnostics for a deployment server. Runs on the self-hosted runner
+# (inside the private network) and prints host/Docker/Swarm/stack/nginx state so
+# deployment failures can be debugged without direct SSH access to the VM.
+#
+# SAFETY: this workflow NEVER prints secret values.
+#   • .env is shown with every value redacted (keys only).
+#   • Nothing is modified — all commands are read-only queries.
+# ─────────────────────────────────────────────────────────────────────────────
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Target environment'
+        required: true
+        type: choice
+        options:
+          - testing
+          - production
+      service:
+        description: 'Optional: docker service name to fetch logs for (e.g. iu_alumni_backend_backend)'
+        required: false
+        type: string
+      tail:
+        description: 'Log lines to tail per service'
+        required: false
+        type: string
+        default: '80'
+
+permissions:
+  contents: read
+
+jobs:
+  diagnose:
+    runs-on: [self-hosted]
+    environment: ${{ inputs.environment }}
+    steps:
+      - name: Collect diagnostics over SSH
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          command_timeout: 5m
+          envs: DEPLOY_DIR,SVC,TAIL
+          script: |
+            set +e
+            echo "══════════ HOST ══════════"
+            uname -a; grep PRETTY_NAME /etc/os-release; uptime
+            echo; echo "══════════ DISK / MEM ══════════"
+            df -h / | tail -2; free -h | head -2
+
+            echo; echo "══════════ DOCKER SERVICE STATUS ══════════"
+            systemctl is-active docker; systemctl status docker --no-pager -l 2>&1 | head -25
+
+            echo; echo "══════════ DOCKER DAEMON JOURNAL (last 60) ══════════"
+            (sudo -n journalctl -xeu docker.service --no-pager -n 60 2>/dev/null \
+              || journalctl -xeu docker.service --no-pager -n 60 2>&1 | head -60 \
+              || echo "journalctl unavailable (needs sudo)")
+
+            echo; echo "══════════ DOCKER / SWARM ══════════"
+            docker version 2>&1 | head -12
+            echo "-- swarm state --"; docker info --format '{{.Swarm.LocalNodeState}} (manager={{.Swarm.ControlAvailable}})' 2>&1
+            echo "-- nodes --"; docker node ls 2>&1 | head -5
+
+            echo; echo "══════════ STACKS / SERVICES ══════════"
+            docker stack ls 2>&1
+            docker service ls 2>&1
+
+            echo; echo "══════════ SERVICE TASKS (failures visible here) ══════════"
+            for s in $(docker service ls --format '{{.Name}}' 2>/dev/null); do
+              echo "--- $s"
+              docker service ps --no-trunc --format '{{.Name}} {{.CurrentState}} {{.Error}}' "$s" 2>&1 | head -6
+            done
+
+            echo; echo "══════════ LOGS ══════════"
+            if [ -n "$SVC" ]; then
+              echo "--- docker service logs $SVC (tail $TAIL)"
+              docker service logs --tail "$TAIL" "$SVC" 2>&1 | tail -"$TAIL"
+            else
+              for s in $(docker service ls --format '{{.Name}}' 2>/dev/null); do
+                echo "--- $s (tail 25)"; docker service logs --tail 25 "$s" 2>&1 | tail -25
+              done
+            fi
+
+            echo; echo "══════════ DEPLOY DIR ══════════"
+            ls -la "$DEPLOY_DIR" 2>&1 | head -20
+
+            echo; echo "══════════ .env KEYS (values redacted) ══════════"
+            if [ -f "$DEPLOY_DIR/.env" ]; then
+              sed -E 's/=.*/=<redacted>/' "$DEPLOY_DIR/.env" | sort
+            else
+              echo "NO .env at $DEPLOY_DIR/.env"
+            fi
+
+            echo; echo "══════════ NGINX CONFIGS (server_name shows active domain) ══════════"
+            ls -la "$DEPLOY_DIR/nginx/conf.d" 2>&1 | head -15
+            grep -h -E "server_name|proxy_pass" "$DEPLOY_DIR"/nginx/conf.d/*.conf 2>/dev/null | head -25
+
+            echo; echo "══════════ LOCAL HTTP CHECKS ══════════"
+            for p in 80 443; do
+              printf 'localhost:%s -> ' "$p"
+              curl -s -o /dev/null -m 5 -w '%{http_code}\n' "http://localhost:$p/" 2>&1 || echo "no answer"
+            done
+
+            echo; echo "══════════ APT LOCK HOLDERS (if setup-server fails) ══════════"
+            ps -eo pid,etime,cmd 2>/dev/null | grep -E '[a]pt|[d]pkg' | head -5 || echo "none"
+            echo; echo "════════ END OF DIAGNOSTICS ════════"
+        env:
+          DEPLOY_DIR: ${{ secrets.DEPLOY_DIR }}
+          SVC: ${{ inputs.service }}
+          TAIL: ${{ inputs.tail }}

--- a/.github/workflows/update-env.yml
+++ b/.github/workflows/update-env.yml
@@ -14,15 +14,17 @@ on:
 jobs:
   update-env-testing:
     if: github.event.inputs.environment == 'testing'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted]
     environment: testing
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install Ansible
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y ansible
+      - name: Install self-hosted runner tools
+        uses: ./.github/actions/bootstrap-self-hosted-tools
+
+      - name: Install Ansible collections
+        working-directory: ansible
+        run: ansible-galaxy collection install -r requirements.yml
 
       - name: Write SSH key
         run: |
@@ -71,15 +73,17 @@ jobs:
 
   update-env-production:
     if: github.event.inputs.environment == 'production'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted]
     environment: production
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install Ansible
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y ansible
+      - name: Install self-hosted runner tools
+        uses: ./.github/actions/bootstrap-self-hosted-tools
+
+      - name: Install Ansible collections
+        working-directory: ansible
+        run: ansible-galaxy collection install -r requirements.yml
 
       - name: Write SSH key
         run: |


### PR DESCRIPTION
## Why

After migrating the servers to private IPs (`10.7.2.33` testing / `10.7.1.19` production), `update-env` fails:

```
fatal: [test-server]: UNREACHABLE! => ssh: connect to host *** port 22: Connection timed out
```

**Root cause:** `update-env.yml` was the last workflow still on `ubuntu-latest`. GitHub-hosted runners can't route to `10.x`. Every other deployment workflow (`setup-server`, `deploy-app`, `deploy-service`) already runs on `[self-hosted]` inside the private network.

## Changes

**1. `update-env.yml` → `[self-hosted]`** (both testing and production jobs)
Also swaps the `apt-get install ansible` step for the same `bootstrap-self-hosted-tools` action + `ansible-galaxy collection install` that `setup-server.yml` uses, so the runner setup is consistent.

**2. New `diagnose.yml`** — read-only server diagnostics, so deployment failures can be debugged without direct SSH to the VM. Dumps:
- host / disk / memory
- `systemctl status docker` + `journalctl -xeu docker.service` (diagnoses the current production Docker failure)
- swarm state, `docker stack ls`, `docker service ls`, per-service task errors
- service logs (all services, or one via the `service` input)
- deploy dir listing, nginx `server_name`/`proxy_pass` (shows which domain is actually served)
- local HTTP checks, apt lock holders (diagnoses the testing `setup-server` apt-lock failure)

**Safety:** nothing is modified — all commands are read-only. Secret values are never printed; `.env` is shown with every value redacted (`KEY=<redacted>`), so we can confirm which keys exist without leaking values.

## Context

This unblocks applying the new domains (`alumap.iudev.tech` testing / `alumap.innopolis.university` production) to the servers, and lets us diagnose:
- production: `docker.service` failing to start on `10.7.1.19`
- testing: `setup-server` blocked by a stuck apt lock

🤖 Generated with [Claude Code](https://claude.com/claude-code)