### PR TITLE
fix(ansible): start docker.socket before dockerd (unblocks production)

### DIFF
--- a/.github/workflows/diagnose.yml
+++ b/.github/workflows/diagnose.yml
@@ -77,13 +77,21 @@ jobs:
             done
 
             echo; echo "══════════ LOGS ══════════"
+            # Application logs can contain credentials (e.g. a bot token inside a
+            # request URL). These repos are public, so Actions logs are public too.
+            # Only dump logs when explicitly asked, and scrub obvious secrets.
+            redact() {
+              sed -E \
+                -e 's#bot[0-9]{5,}:[A-Za-z0-9_-]{20,}#bot<REDACTED>#g' \
+                -e 's#(password|passwd|token|secret|api[_-]?key|authorization)([=:"[:space:]]+)[^"[:space:],]+#\1\2<REDACTED>#gI' \
+                -e 's#(https?://)[^:/@[:space:]]+:[^@[:space:]]+@#\1<REDACTED>@#g'
+            }
             if [ -n "$SVC" ]; then
-              echo "--- docker service logs $SVC (tail $TAIL)"
-              docker service logs --tail "$TAIL" "$SVC" 2>&1 | tail -"$TAIL"
+              echo "--- docker service logs $SVC (tail $TAIL, secrets scrubbed)"
+              docker service logs --tail "$TAIL" "$SVC" 2>&1 | tail -"$TAIL" | redact
             else
-              for s in $(docker service ls --format '{{.Name}}' 2>/dev/null); do
-                echo "--- $s (tail 25)"; docker service logs --tail 25 "$s" 2>&1 | tail -25
-              done
+              echo "(skipped — pass the 'service' input to dump logs for one service)"
+              echo "Task state above already shows crash/restart errors without log contents."
             fi
 
             echo; echo "══════════ DEPLOY DIR ══════════"

--- a/ansible/playbooks/setup-server.yml
+++ b/ansible/playbooks/setup-server.yml
@@ -21,11 +21,13 @@
     # ── System packages ──────────────────────────────────
     - name: Update apt cache
       ansible.builtin.apt:
+        lock_timeout: 300
         update_cache: true
         cache_valid_time: 3600
 
     - name: Install essential packages
       ansible.builtin.apt:
+        lock_timeout: 300
         name:
           - curl
           - wget
@@ -76,6 +78,7 @@
 
     - name: Install Docker
       ansible.builtin.apt:
+        lock_timeout: 300
         name:
           - docker-ce
           - docker-ce-cli
@@ -83,6 +86,25 @@
           - docker-compose-plugin
         state: present
         update_cache: true
+
+    # docker.service starts dockerd with `-H fd://`, which requires docker.socket
+    # to be active. When docker-ce replaces a pre-existing docker.io install the
+    # socket unit can be left disabled, and dockerd then dies with
+    #   "failed to load listeners: no sockets found via socket activation"
+    # Enable/start the socket first so the daemon has its listener.
+    - name: Ensure docker.socket is enabled and started
+      ansible.builtin.systemd:
+        name: docker.socket
+        state: started
+        enabled: true
+        daemon_reload: true
+
+    # After 3 rapid failures systemd latches "start request repeated too quickly"
+    # and refuses further starts until the unit's failed state is cleared.
+    - name: Clear any latched docker.service failure state
+      ansible.builtin.command: systemctl reset-failed docker.service
+      changed_when: false
+      failed_when: false
 
     - name: Start and enable Docker
       ansible.builtin.systemd:


### PR DESCRIPTION
Production `dockerd` fails with `failed to load listeners: no sockets found via socket activation` after docker-ce replaced the distro docker.io package. `docker.service` uses `-H fd://` and needs `docker.socket` active.

- enable/start `docker.socket` before starting dockerd
- `systemctl reset-failed docker.service` to clear systemd's latched 'start request repeated too quickly'
- `lock_timeout: 300` on apt tasks (testing setup-server failed on a held apt lock)
- diagnose: no longer dumps every service's logs (public repo + app logs can contain credentials); requires explicit `service` input and scrubs secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)