### PR TITLE
fix(smoke): pass DEPLOY_DIR to the ssh step

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -58,6 +58,7 @@ jobs:
           envs: DEPLOY_DIR
           script: |
             set -u
+            DEPLOY_DIR="${DEPLOY_DIR:-/home/deploy/iu-alumni}"
             failures=0
             fail() { echo "  FAIL: $*"; failures=$((failures + 1)); }
             pass() { echo "  ok:   $*"; }
@@ -117,3 +118,5 @@ jobs:
               exit 1
             fi
             echo "SMOKE TEST PASSED: all checks green"
+        env:
+          DEPLOY_DIR: ${{ secrets.DEPLOY_DIR }}


### PR DESCRIPTION
The smoke test declared `envs: DEPLOY_DIR` but never defined `DEPLOY_DIR` on the step, so under `set -u` the script aborted at the first reference — swarm checks ran, then the vhost and backend assertions were silently skipped and the job failed.

Defines it from the secret (with a default), matching `diagnose.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)