### PR TITLE
fix(diagnose): repair mangled quoting that broke the remote script

### DIFF
--- a/.github/workflows/diagnose.yml
+++ b/.github/workflows/diagnose.yml
@@ -138,7 +138,7 @@ jobs:
             # request only proves the default server. Probe each vhost by name to
             # confirm the app behind it actually answers on this box.
             echo "-- per-vhost (Host header -> nginx on :80) --"
-            DOM=$(grep -E '^DOMAIN=' "$DEPLOY_DIR/.env" 2>/dev/null | cut -d= -f2- | tr -d '"'"'"'')
+            DOM=$(grep -E '^DOMAIN=' "$DEPLOY_DIR/.env" 2>/dev/null | cut -d= -f2- | tr -d '"')
             if [ -n "$DOM" ]; then
               for entry in "app:${DOM}" "api:api.${DOM}" "mobile:mobile.${DOM}" \
                            "admin:admin.${DOM}" "grafana:grafana.${DOM}" "portainer:portainer.${DOM}"; do


### PR DESCRIPTION
The DOMAIN extraction line ended with:

```
tr -d '"'"'"''
```

— an **unbalanced quote** left behind by an earlier scripted edit. zsh then mis-parsed the remainder of the script, which explains two symptoms that looked unrelated:

1. the api-path probes silently returning `no-response` (noted but not chased at the time)
2. the new ingress section failing with `command not found` for every command *after a pipe*, while standalone commands kept working

Restores a plain `tr -d '"'`. `smoke-test.yml` has the same extraction written correctly, which is why it was never affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)