### PR TITLE
fix(diagnose): repair unbalanced quote in DOMAIN extraction

### DIFF
--- a/.github/workflows/diagnose.yml
+++ b/.github/workflows/diagnose.yml
@@ -138,7 +138,7 @@ jobs:
             # request only proves the default server. Probe each vhost by name to
             # confirm the app behind it actually answers on this box.
             echo "-- per-vhost (Host header -> nginx on :80) --"
-            DOM=$(grep -E '^DOMAIN=' "$DEPLOY_DIR/.env" 2>/dev/null | cut -d= -f2- | tr -d '"'"'"'')
+            DOM=$(grep -E '^DOMAIN=' "$DEPLOY_DIR/.env" 2>/dev/null | cut -d= -f2- | tr -d '"')
             if [ -n "$DOM" ]; then
               for entry in "app:${DOM}" "api:api.${DOM}" "mobile:mobile.${DOM}" \
                            "admin:admin.${DOM}" "grafana:grafana.${DOM}" "portainer:portainer.${DOM}"; do


### PR DESCRIPTION
`tr -d '"'"'"''` — an unbalanced single quote left by an earlier scripted edit. zsh mis-parses everything after it, which produced two symptoms that looked unrelated: the api-path probes silently returning `no-response`, and the ingress section failing with `command not found` for every command after a pipe while standalone commands kept working.

`smoke-test.yml` has the same extraction written correctly, which is why it was never affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)