### PR TITLE
fix(diagnose): call ingress tools by absolute path

### DIFF
--- a/.github/workflows/diagnose.yml
+++ b/.github/workflows/diagnose.yml
@@ -159,39 +159,36 @@ jobs:
             fi
 
             echo; echo "══════════ INGRESS PATH ══════════"
-            # The public hostnames resolve to the university's Angie ingress, which
-            # answers 403 externally. The question this section settles is whether
-            # Angie forwards to us at all: if our nginx never logs a request from
-            # the ingress, the request is being refused upstream of us.
+            # Every tool here is called by absolute path on purpose: the outer
+            # session is zsh and its PATH stops resolving partway through a long
+            # script, so piped commands failed with "command not found" while
+            # standalone ones kept working.
+            #
+            # This settles whether the university's Angie ingress forwards to us
+            # at all. If our nginx access log never shows a request arriving from
+            # the ingress, the 403 happens upstream and no nginx change on our
+            # side can fix it.
             echo "-- what is listening on 80/443 --"
-            (ss -lntp 2>/dev/null || netstat -lntp 2>/dev/null) | grep -E ':(80|443) ' | head -6
+            /usr/bin/ss -lntp 2>/dev/null | /usr/bin/grep -E ':(80|443) ' | /usr/bin/head -6
 
-            echo "-- nginx request sources (last 2000 log lines, by client IP) --"
-            # Access logs go to stdout, so they come from the service log. Query
-            # strings are stripped: verification links carry ?token=... and these
-            # repos are public.
-            docker service logs --tail 2000 iu_alumni_infra_nginx 2>&1 \
-              | sed -E 's/\?[^ "]*/?<scrubbed>/g' \
-              | grep -oE '^[^|]*\| *[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' \
-              | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' \
-              | sort | uniq -c | sort -rn | head -10 \
-              || echo "  (no client IPs parsed from nginx logs)"
+            # Access logs go to the service log. Query strings are stripped:
+            # verification links carry ?token=... and these repos are public.
+            echo "-- client IPs reaching our nginx (last 2000 log lines) --"
+            /usr/bin/docker service logs --tail 2000 iu_alumni_infra_nginx 2>&1 | /usr/bin/sed -E 's/\?[^ "]*/?<scrubbed>/g' | /usr/bin/grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | /usr/bin/sort | /usr/bin/uniq -c | /usr/bin/sort -rn | /usr/bin/head -10
 
-            echo "-- recent nginx requests (scrubbed) --"
-            docker service logs --tail 40 iu_alumni_infra_nginx 2>&1 \
-              | sed -E 's/\?[^ "]*/?<scrubbed>/g' | tail -15
+            echo "-- recent nginx request lines (scrubbed) --"
+            /usr/bin/docker service logs --tail 40 iu_alumni_infra_nginx 2>&1 | /usr/bin/sed -E 's/\?[^ "]*/?<scrubbed>/g' | /usr/bin/tail -12
 
-            echo "-- can this server reach its own public hostname (through the ingress)? --"
             if [ -n "$DOM" ]; then
+              echo "-- through the ingress (public hostname) --"
               for host in "$DOM" "api.$DOM"; do
                 printf '  https://%s -> ' "$host"
-                curl -s -o /dev/null -m 15 -w '%{http_code} (server: %{scheme})\n' "https://${host}/" 2>&1 \
-                  || echo "no answer"
+                /usr/bin/curl -s -o /dev/null -m 15 -w '%{http_code}\n' "https://${host}/" 2>&1 || echo "no answer"
               done
-              echo "  -- same hostname, but straight at our own nginx --"
+              echo "-- straight at our own nginx (same hostname) --"
               for host in "$DOM" "api.$DOM"; do
                 printf '  Host:%s -> localhost:80 -> ' "$host"
-                curl -s -o /dev/null -m 10 -w '%{http_code}\n' -H "Host: ${host}" http://localhost/ 2>&1
+                /usr/bin/curl -s -o /dev/null -m 10 -w '%{http_code}\n' -H "Host: ${host}" http://localhost/ 2>&1
               done
             fi
 


### PR DESCRIPTION
The outer SSH session is zsh and its PATH stops resolving partway through the script — `grep` works at the top, then every piped command in the ingress section fails with `command not found` while standalone commands keep working. Exporting PATH didn't help, and piping into `bash -l` isn't possible inside a YAML block scalar (the heredoc terminator would have to sit at column 0, which ends the block).

Calling each tool by absolute path sidesteps the shell entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)