### PR TITLE
fix(ci): stop the shell eating $ inside secret values

### DIFF
--- a/.github/workflows/setup-server.yml
+++ b/.github/workflows/setup-server.yml
@@ -46,38 +46,65 @@ jobs:
         working-directory: ansible
         env:
           ANSIBLE_HOST_KEY_CHECKING: "false"
+          ADMIN_CHAT_ID: ${{ secrets.ADMIN_CHAT_ID }}
+          ADMIN_EMAIL: ${{ secrets.ADMIN_EMAIL }}
+          ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD }}
+          CERTBOT_EMAIL: ${{ secrets.CERTBOT_EMAIL }}
+          CORS_ORIGINS: ${{ secrets.CORS_ORIGINS }}
+          DEPLOY_DIR: ${{ secrets.DEPLOY_DIR }}
+          DOMAIN: ${{ secrets.DOMAIN }}
+          EMAIL_HASH_SECRET: ${{ secrets.EMAIL_HASH_SECRET }}
+          ENVIRONMENT: ${{ secrets.ENVIRONMENT }}
+          GRAFANA_PASSWORD: ${{ secrets.GRAFANA_PASSWORD }}
+          GRAFANA_USER: ${{ secrets.GRAFANA_USER }}
+          LOGIN_CODE_EXPIRY_MINUTES: ${{ secrets.LOGIN_CODE_EXPIRY_MINUTES }}
+          MAIL_FROM: ${{ secrets.MAIL_FROM }}
+          MAIL_FROM_NAME: ${{ secrets.MAIL_FROM_NAME }}
+          MAIL_PASSWORD: ${{ secrets.MAIL_PASSWORD }}
+          MAIL_PORT: ${{ secrets.MAIL_PORT }}
+          MAIL_SERVER: ${{ secrets.MAIL_SERVER }}
+          MAIL_USERNAME: ${{ secrets.MAIL_USERNAME }}
+          MINI_APP_URL: ${{ secrets.MINI_APP_URL }}
+          PASSWORD_RESET_EXPIRY_MINUTES: ${{ secrets.PASSWORD_RESET_EXPIRY_MINUTES }}
+          POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
+          SECRET_KEY: ${{ secrets.SECRET_KEY }}
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+          SERVER_USER: ${{ secrets.SERVER_USER }}
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_TOKEN }}
         run: |
           ansible-playbook playbooks/setup-server.yml \
             --limit testing \
-            -e "server_ip=${{ secrets.SERVER_HOST }}" \
-            -e "server_user=${{ secrets.SERVER_USER }}" \
+            -e "server_ip=$SERVER_HOST" \
+            -e "server_user=$SERVER_USER" \
             -e "ghcr_user=${{ github.actor }}" \
-            -e "deploy_dir=${{ secrets.DEPLOY_DIR }}" \
-            -e "domain=${{ secrets.DOMAIN }}" \
-            -e "certbot_email=${{ secrets.CERTBOT_EMAIL }}" \
+            -e "deploy_dir=$DEPLOY_DIR" \
+            -e "domain=$DOMAIN" \
+            -e "certbot_email=$CERTBOT_EMAIL" \
             -e "setup_certificates=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.setup_certificates || false }}" \
-            -e "postgres_password=${{ secrets.POSTGRES_PASSWORD }}" \
-            -e "postgres_user=${{ secrets.POSTGRES_USER }}" \
-            -e "postgres_db=${{ secrets.POSTGRES_DB }}" \
-            -e "secret_key=${{ secrets.SECRET_KEY }}" \
-            -e "admin_email=${{ secrets.ADMIN_EMAIL }}" \
-            -e "admin_password=${{ secrets.ADMIN_PASSWORD }}" \
-            -e "email_hash_secret=${{ secrets.EMAIL_HASH_SECRET }}" \
-            -e "mail_username=${{ secrets.MAIL_USERNAME }}" \
-            -e "mail_password=${{ secrets.MAIL_PASSWORD }}" \
-            -e "mail_from=${{ secrets.MAIL_FROM }}" \
-            -e "mail_from_name=${{ secrets.MAIL_FROM_NAME }}" \
-            -e "mail_server=${{ secrets.MAIL_SERVER }}" \
-            -e "mail_port=${{ secrets.MAIL_PORT }}" \
-            -e "telegram_token=${{ secrets.TELEGRAM_TOKEN }}" \
-            -e "admin_chat_id=${{ secrets.ADMIN_CHAT_ID }}" \
-            -e "mini_app_url=${{ secrets.MINI_APP_URL }}" \
-            -e "grafana_user=${{ secrets.GRAFANA_USER }}" \
-            -e "grafana_password=${{ secrets.GRAFANA_PASSWORD }}" \
-            -e "app_environment=${{ secrets.ENVIRONMENT }}" \
-            -e "cors_origins=${{ secrets.CORS_ORIGINS }}" \
-            -e "login_code_expiry_minutes=${{ secrets.LOGIN_CODE_EXPIRY_MINUTES }}" \
-            -e "password_reset_expiry_minutes=${{ secrets.PASSWORD_RESET_EXPIRY_MINUTES }}" \
+            -e "postgres_password=$POSTGRES_PASSWORD" \
+            -e "postgres_user=$POSTGRES_USER" \
+            -e "postgres_db=$POSTGRES_DB" \
+            -e "secret_key=$SECRET_KEY" \
+            -e "admin_email=$ADMIN_EMAIL" \
+            -e "admin_password=$ADMIN_PASSWORD" \
+            -e "email_hash_secret=$EMAIL_HASH_SECRET" \
+            -e "mail_username=$MAIL_USERNAME" \
+            -e "mail_password=$MAIL_PASSWORD" \
+            -e "mail_from=$MAIL_FROM" \
+            -e "mail_from_name=$MAIL_FROM_NAME" \
+            -e "mail_server=$MAIL_SERVER" \
+            -e "mail_port=$MAIL_PORT" \
+            -e "telegram_token=$TELEGRAM_TOKEN" \
+            -e "admin_chat_id=$ADMIN_CHAT_ID" \
+            -e "mini_app_url=$MINI_APP_URL" \
+            -e "grafana_user=$GRAFANA_USER" \
+            -e "grafana_password=$GRAFANA_PASSWORD" \
+            -e "app_environment=$ENVIRONMENT" \
+            -e "cors_origins=$CORS_ORIGINS" \
+            -e "login_code_expiry_minutes=$LOGIN_CODE_EXPIRY_MINUTES" \
+            -e "password_reset_expiry_minutes=$PASSWORD_RESET_EXPIRY_MINUTES" \
             --private-key /home/deploy/.ssh/deploy
       - name: Bootstrap infrastructure (first deploy)
         uses: appleboy/ssh-action@v1
@@ -121,38 +148,65 @@ jobs:
         working-directory: ansible
         env:
           ANSIBLE_HOST_KEY_CHECKING: "false"
+          ADMIN_CHAT_ID: ${{ secrets.ADMIN_CHAT_ID }}
+          ADMIN_EMAIL: ${{ secrets.ADMIN_EMAIL }}
+          ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD }}
+          CERTBOT_EMAIL: ${{ secrets.CERTBOT_EMAIL }}
+          CORS_ORIGINS: ${{ secrets.CORS_ORIGINS }}
+          DEPLOY_DIR: ${{ secrets.DEPLOY_DIR }}
+          DOMAIN: ${{ secrets.DOMAIN }}
+          EMAIL_HASH_SECRET: ${{ secrets.EMAIL_HASH_SECRET }}
+          ENVIRONMENT: ${{ secrets.ENVIRONMENT }}
+          GRAFANA_PASSWORD: ${{ secrets.GRAFANA_PASSWORD }}
+          GRAFANA_USER: ${{ secrets.GRAFANA_USER }}
+          LOGIN_CODE_EXPIRY_MINUTES: ${{ secrets.LOGIN_CODE_EXPIRY_MINUTES }}
+          MAIL_FROM: ${{ secrets.MAIL_FROM }}
+          MAIL_FROM_NAME: ${{ secrets.MAIL_FROM_NAME }}
+          MAIL_PASSWORD: ${{ secrets.MAIL_PASSWORD }}
+          MAIL_PORT: ${{ secrets.MAIL_PORT }}
+          MAIL_SERVER: ${{ secrets.MAIL_SERVER }}
+          MAIL_USERNAME: ${{ secrets.MAIL_USERNAME }}
+          MINI_APP_URL: ${{ secrets.MINI_APP_URL }}
+          PASSWORD_RESET_EXPIRY_MINUTES: ${{ secrets.PASSWORD_RESET_EXPIRY_MINUTES }}
+          POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
+          SECRET_KEY: ${{ secrets.SECRET_KEY }}
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+          SERVER_USER: ${{ secrets.SERVER_USER }}
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_TOKEN }}
         run: |
           ansible-playbook playbooks/setup-server.yml \
             --limit production \
-            -e "server_ip=${{ secrets.SERVER_HOST }}" \
-            -e "server_user=${{ secrets.SERVER_USER }}" \
+            -e "server_ip=$SERVER_HOST" \
+            -e "server_user=$SERVER_USER" \
             -e "ghcr_user=${{ github.actor }}" \
-            -e "deploy_dir=${{ secrets.DEPLOY_DIR }}" \
-            -e "domain=${{ secrets.DOMAIN }}" \
-            -e "certbot_email=${{ secrets.CERTBOT_EMAIL }}" \
+            -e "deploy_dir=$DEPLOY_DIR" \
+            -e "domain=$DOMAIN" \
+            -e "certbot_email=$CERTBOT_EMAIL" \
             -e "setup_certificates=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.setup_certificates || false }}" \
-            -e "postgres_password=${{ secrets.POSTGRES_PASSWORD }}" \
-            -e "postgres_user=${{ secrets.POSTGRES_USER }}" \
-            -e "postgres_db=${{ secrets.POSTGRES_DB }}" \
-            -e "secret_key=${{ secrets.SECRET_KEY }}" \
-            -e "admin_email=${{ secrets.ADMIN_EMAIL }}" \
-            -e "admin_password=${{ secrets.ADMIN_PASSWORD }}" \
-            -e "email_hash_secret=${{ secrets.EMAIL_HASH_SECRET }}" \
-            -e "mail_username=${{ secrets.MAIL_USERNAME }}" \
-            -e "mail_password=${{ secrets.MAIL_PASSWORD }}" \
-            -e "mail_from=${{ secrets.MAIL_FROM }}" \
-            -e "mail_from_name=${{ secrets.MAIL_FROM_NAME }}" \
-            -e "mail_server=${{ secrets.MAIL_SERVER }}" \
-            -e "mail_port=${{ secrets.MAIL_PORT }}" \
-            -e "telegram_token=${{ secrets.TELEGRAM_TOKEN }}" \
-            -e "admin_chat_id=${{ secrets.ADMIN_CHAT_ID }}" \
-            -e "mini_app_url=${{ secrets.MINI_APP_URL }}" \
-            -e "grafana_user=${{ secrets.GRAFANA_USER }}" \
-            -e "grafana_password=${{ secrets.GRAFANA_PASSWORD }}" \
-            -e "app_environment=${{ secrets.ENVIRONMENT }}" \
-            -e "cors_origins=${{ secrets.CORS_ORIGINS }}" \
-            -e "login_code_expiry_minutes=${{ secrets.LOGIN_CODE_EXPIRY_MINUTES }}" \
-            -e "password_reset_expiry_minutes=${{ secrets.PASSWORD_RESET_EXPIRY_MINUTES }}" \
+            -e "postgres_password=$POSTGRES_PASSWORD" \
+            -e "postgres_user=$POSTGRES_USER" \
+            -e "postgres_db=$POSTGRES_DB" \
+            -e "secret_key=$SECRET_KEY" \
+            -e "admin_email=$ADMIN_EMAIL" \
+            -e "admin_password=$ADMIN_PASSWORD" \
+            -e "email_hash_secret=$EMAIL_HASH_SECRET" \
+            -e "mail_username=$MAIL_USERNAME" \
+            -e "mail_password=$MAIL_PASSWORD" \
+            -e "mail_from=$MAIL_FROM" \
+            -e "mail_from_name=$MAIL_FROM_NAME" \
+            -e "mail_server=$MAIL_SERVER" \
+            -e "mail_port=$MAIL_PORT" \
+            -e "telegram_token=$TELEGRAM_TOKEN" \
+            -e "admin_chat_id=$ADMIN_CHAT_ID" \
+            -e "mini_app_url=$MINI_APP_URL" \
+            -e "grafana_user=$GRAFANA_USER" \
+            -e "grafana_password=$GRAFANA_PASSWORD" \
+            -e "app_environment=$ENVIRONMENT" \
+            -e "cors_origins=$CORS_ORIGINS" \
+            -e "login_code_expiry_minutes=$LOGIN_CODE_EXPIRY_MINUTES" \
+            -e "password_reset_expiry_minutes=$PASSWORD_RESET_EXPIRY_MINUTES" \
             --private-key /home/deploy/.ssh/deploy
       - name: Bootstrap infrastructure (first deploy)
         uses: appleboy/ssh-action@v1

--- a/.github/workflows/update-env.yml
+++ b/.github/workflows/update-env.yml
@@ -37,38 +37,65 @@ jobs:
         working-directory: ansible
         env:
           ANSIBLE_HOST_KEY_CHECKING: "false"
+          ADMIN_CHAT_ID: ${{ secrets.ADMIN_CHAT_ID }}
+          ADMIN_EMAIL: ${{ secrets.ADMIN_EMAIL }}
+          ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD }}
+          CERTBOT_EMAIL: ${{ secrets.CERTBOT_EMAIL }}
+          CORS_ORIGINS: ${{ secrets.CORS_ORIGINS }}
+          DEPLOY_DIR: ${{ secrets.DEPLOY_DIR }}
+          DOMAIN: ${{ secrets.DOMAIN }}
+          EMAIL_HASH_SECRET: ${{ secrets.EMAIL_HASH_SECRET }}
+          ENVIRONMENT: ${{ secrets.ENVIRONMENT }}
+          GRAFANA_PASSWORD: ${{ secrets.GRAFANA_PASSWORD }}
+          GRAFANA_USER: ${{ secrets.GRAFANA_USER }}
+          LOGIN_CODE_EXPIRY_MINUTES: ${{ secrets.LOGIN_CODE_EXPIRY_MINUTES }}
+          MAIL_FROM: ${{ secrets.MAIL_FROM }}
+          MAIL_FROM_NAME: ${{ secrets.MAIL_FROM_NAME }}
+          MAIL_PASSWORD: ${{ secrets.MAIL_PASSWORD }}
+          MAIL_PORT: ${{ secrets.MAIL_PORT }}
+          MAIL_SERVER: ${{ secrets.MAIL_SERVER }}
+          MAIL_USERNAME: ${{ secrets.MAIL_USERNAME }}
+          MINI_APP_URL: ${{ secrets.MINI_APP_URL }}
+          PASSWORD_RESET_EXPIRY_MINUTES: ${{ secrets.PASSWORD_RESET_EXPIRY_MINUTES }}
+          POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
+          SECRET_KEY: ${{ secrets.SECRET_KEY }}
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+          SERVER_USER: ${{ secrets.SERVER_USER }}
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_TOKEN }}
         run: |
           ansible-playbook playbooks/setup-server.yml \
             --limit testing \
             --tags env \
-            -e "server_ip=${{ secrets.SERVER_HOST }}" \
-            -e "server_user=${{ secrets.SERVER_USER }}" \
+            -e "server_ip=$SERVER_HOST" \
+            -e "server_user=$SERVER_USER" \
             -e "ghcr_user=${{ github.actor }}" \
-            -e "deploy_dir=${{ secrets.DEPLOY_DIR }}" \
-            -e "domain=${{ secrets.DOMAIN }}" \
-            -e "certbot_email=${{ secrets.CERTBOT_EMAIL }}" \
-            -e "postgres_password=${{ secrets.POSTGRES_PASSWORD }}" \
-            -e "postgres_user=${{ secrets.POSTGRES_USER }}" \
-            -e "postgres_db=${{ secrets.POSTGRES_DB }}" \
-            -e "secret_key=${{ secrets.SECRET_KEY }}" \
-            -e "admin_email=${{ secrets.ADMIN_EMAIL }}" \
-            -e "admin_password=${{ secrets.ADMIN_PASSWORD }}" \
-            -e "email_hash_secret=${{ secrets.EMAIL_HASH_SECRET }}" \
-            -e "mail_username=${{ secrets.MAIL_USERNAME }}" \
-            -e "mail_password=${{ secrets.MAIL_PASSWORD }}" \
-            -e "mail_from=${{ secrets.MAIL_FROM }}" \
-            -e "mail_from_name=${{ secrets.MAIL_FROM_NAME }}" \
-            -e "mail_server=${{ secrets.MAIL_SERVER }}" \
-            -e "mail_port=${{ secrets.MAIL_PORT }}" \
-            -e "telegram_token=${{ secrets.TELEGRAM_TOKEN }}" \
-            -e "admin_chat_id=${{ secrets.ADMIN_CHAT_ID }}" \
-            -e "mini_app_url=${{ secrets.MINI_APP_URL }}" \
-            -e "grafana_user=${{ secrets.GRAFANA_USER }}" \
-            -e "grafana_password=${{ secrets.GRAFANA_PASSWORD }}" \
-            -e "app_environment=${{ secrets.ENVIRONMENT }}" \
-            -e "cors_origins=${{ secrets.CORS_ORIGINS }}" \
-            -e "login_code_expiry_minutes=${{ secrets.LOGIN_CODE_EXPIRY_MINUTES }}" \
-            -e "password_reset_expiry_minutes=${{ secrets.PASSWORD_RESET_EXPIRY_MINUTES }}" \
+            -e "deploy_dir=$DEPLOY_DIR" \
+            -e "domain=$DOMAIN" \
+            -e "certbot_email=$CERTBOT_EMAIL" \
+            -e "postgres_password=$POSTGRES_PASSWORD" \
+            -e "postgres_user=$POSTGRES_USER" \
+            -e "postgres_db=$POSTGRES_DB" \
+            -e "secret_key=$SECRET_KEY" \
+            -e "admin_email=$ADMIN_EMAIL" \
+            -e "admin_password=$ADMIN_PASSWORD" \
+            -e "email_hash_secret=$EMAIL_HASH_SECRET" \
+            -e "mail_username=$MAIL_USERNAME" \
+            -e "mail_password=$MAIL_PASSWORD" \
+            -e "mail_from=$MAIL_FROM" \
+            -e "mail_from_name=$MAIL_FROM_NAME" \
+            -e "mail_server=$MAIL_SERVER" \
+            -e "mail_port=$MAIL_PORT" \
+            -e "telegram_token=$TELEGRAM_TOKEN" \
+            -e "admin_chat_id=$ADMIN_CHAT_ID" \
+            -e "mini_app_url=$MINI_APP_URL" \
+            -e "grafana_user=$GRAFANA_USER" \
+            -e "grafana_password=$GRAFANA_PASSWORD" \
+            -e "app_environment=$ENVIRONMENT" \
+            -e "cors_origins=$CORS_ORIGINS" \
+            -e "login_code_expiry_minutes=$LOGIN_CODE_EXPIRY_MINUTES" \
+            -e "password_reset_expiry_minutes=$PASSWORD_RESET_EXPIRY_MINUTES" \
             --private-key ~/.ssh/deploy
 
   update-env-production:
@@ -96,36 +123,63 @@ jobs:
         working-directory: ansible
         env:
           ANSIBLE_HOST_KEY_CHECKING: "false"
+          ADMIN_CHAT_ID: ${{ secrets.ADMIN_CHAT_ID }}
+          ADMIN_EMAIL: ${{ secrets.ADMIN_EMAIL }}
+          ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD }}
+          CERTBOT_EMAIL: ${{ secrets.CERTBOT_EMAIL }}
+          CORS_ORIGINS: ${{ secrets.CORS_ORIGINS }}
+          DEPLOY_DIR: ${{ secrets.DEPLOY_DIR }}
+          DOMAIN: ${{ secrets.DOMAIN }}
+          EMAIL_HASH_SECRET: ${{ secrets.EMAIL_HASH_SECRET }}
+          ENVIRONMENT: ${{ secrets.ENVIRONMENT }}
+          GRAFANA_PASSWORD: ${{ secrets.GRAFANA_PASSWORD }}
+          GRAFANA_USER: ${{ secrets.GRAFANA_USER }}
+          LOGIN_CODE_EXPIRY_MINUTES: ${{ secrets.LOGIN_CODE_EXPIRY_MINUTES }}
+          MAIL_FROM: ${{ secrets.MAIL_FROM }}
+          MAIL_FROM_NAME: ${{ secrets.MAIL_FROM_NAME }}
+          MAIL_PASSWORD: ${{ secrets.MAIL_PASSWORD }}
+          MAIL_PORT: ${{ secrets.MAIL_PORT }}
+          MAIL_SERVER: ${{ secrets.MAIL_SERVER }}
+          MAIL_USERNAME: ${{ secrets.MAIL_USERNAME }}
+          MINI_APP_URL: ${{ secrets.MINI_APP_URL }}
+          PASSWORD_RESET_EXPIRY_MINUTES: ${{ secrets.PASSWORD_RESET_EXPIRY_MINUTES }}
+          POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
+          SECRET_KEY: ${{ secrets.SECRET_KEY }}
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+          SERVER_USER: ${{ secrets.SERVER_USER }}
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_TOKEN }}
         run: |
           ansible-playbook playbooks/setup-server.yml \
             --limit production \
             --tags env \
-            -e "server_ip=${{ secrets.SERVER_HOST }}" \
-            -e "server_user=${{ secrets.SERVER_USER }}" \
+            -e "server_ip=$SERVER_HOST" \
+            -e "server_user=$SERVER_USER" \
             -e "ghcr_user=${{ github.actor }}" \
-            -e "deploy_dir=${{ secrets.DEPLOY_DIR }}" \
-            -e "domain=${{ secrets.DOMAIN }}" \
-            -e "certbot_email=${{ secrets.CERTBOT_EMAIL }}" \
-            -e "postgres_password=${{ secrets.POSTGRES_PASSWORD }}" \
-            -e "postgres_user=${{ secrets.POSTGRES_USER }}" \
-            -e "postgres_db=${{ secrets.POSTGRES_DB }}" \
-            -e "secret_key=${{ secrets.SECRET_KEY }}" \
-            -e "admin_email=${{ secrets.ADMIN_EMAIL }}" \
-            -e "admin_password=${{ secrets.ADMIN_PASSWORD }}" \
-            -e "email_hash_secret=${{ secrets.EMAIL_HASH_SECRET }}" \
-            -e "mail_username=${{ secrets.MAIL_USERNAME }}" \
-            -e "mail_password=${{ secrets.MAIL_PASSWORD }}" \
-            -e "mail_from=${{ secrets.MAIL_FROM }}" \
-            -e "mail_from_name=${{ secrets.MAIL_FROM_NAME }}" \
-            -e "mail_server=${{ secrets.MAIL_SERVER }}" \
-            -e "mail_port=${{ secrets.MAIL_PORT }}" \
-            -e "telegram_token=${{ secrets.TELEGRAM_TOKEN }}" \
-            -e "admin_chat_id=${{ secrets.ADMIN_CHAT_ID }}" \
-            -e "mini_app_url=${{ secrets.MINI_APP_URL }}" \
-            -e "grafana_user=${{ secrets.GRAFANA_USER }}" \
-            -e "grafana_password=${{ secrets.GRAFANA_PASSWORD }}" \
-            -e "app_environment=${{ secrets.ENVIRONMENT }}" \
-            -e "cors_origins=${{ secrets.CORS_ORIGINS }}" \
-            -e "login_code_expiry_minutes=${{ secrets.LOGIN_CODE_EXPIRY_MINUTES }}" \
-            -e "password_reset_expiry_minutes=${{ secrets.PASSWORD_RESET_EXPIRY_MINUTES }}" \
+            -e "deploy_dir=$DEPLOY_DIR" \
+            -e "domain=$DOMAIN" \
+            -e "certbot_email=$CERTBOT_EMAIL" \
+            -e "postgres_password=$POSTGRES_PASSWORD" \
+            -e "postgres_user=$POSTGRES_USER" \
+            -e "postgres_db=$POSTGRES_DB" \
+            -e "secret_key=$SECRET_KEY" \
+            -e "admin_email=$ADMIN_EMAIL" \
+            -e "admin_password=$ADMIN_PASSWORD" \
+            -e "email_hash_secret=$EMAIL_HASH_SECRET" \
+            -e "mail_username=$MAIL_USERNAME" \
+            -e "mail_password=$MAIL_PASSWORD" \
+            -e "mail_from=$MAIL_FROM" \
+            -e "mail_from_name=$MAIL_FROM_NAME" \
+            -e "mail_server=$MAIL_SERVER" \
+            -e "mail_port=$MAIL_PORT" \
+            -e "telegram_token=$TELEGRAM_TOKEN" \
+            -e "admin_chat_id=$ADMIN_CHAT_ID" \
+            -e "mini_app_url=$MINI_APP_URL" \
+            -e "grafana_user=$GRAFANA_USER" \
+            -e "grafana_password=$GRAFANA_PASSWORD" \
+            -e "app_environment=$ENVIRONMENT" \
+            -e "cors_origins=$CORS_ORIGINS" \
+            -e "login_code_expiry_minutes=$LOGIN_CODE_EXPIRY_MINUTES" \
+            -e "password_reset_expiry_minutes=$PASSWORD_RESET_EXPIRY_MINUTES" \
             --private-key ~/.ssh/deploy


### PR DESCRIPTION
## The bug

Secrets were interpolated directly into a **double-quoted shell string**:

```yaml
-e "mail_password=${{ secrets.MAIL_PASSWORD }}"
```

The runner's shell expands any `$…` sequence **inside the secret** before Ansible ever sees it. `MAIL_PASSWORD` contains a `$`, so two characters were silently deleted in transit:

| stage | length | sha256 |
|---|---|---|
| `terraform.tfvars` (intended) | **28** | `79df62b3…` |
| server `.env` | **26** | `1294ae5e…` |
| inside the container | **26** | `1294ae5e…` |

That is why SMTP auth fails with a password that is correct — the app is presenting a truncated one.

## Blast radius, measured

I hashed every credential end to end rather than guessing. `MAIL_PASSWORD` is the **only** one affected today, because it's the only one containing `$`:

| secret | status |
|---|---|
| MAIL_PASSWORD | ❌ corrupted (26 vs 28) |
| POSTGRES_PASSWORD, SECRET_KEY, ADMIN_PASSWORD, EMAIL_HASH_SECRET, TELEGRAM_TOKEN, GRAFANA_PASSWORD, POSTGRES_USER, MAIL_USERNAME, ADMIN_EMAIL | ✅ match |

So no data was written with a wrong password — but any future secret containing `$`, a backtick or `\` would have hit the same trap.

## The fix

All 54 secret interpolations per workflow now go through the step's `env:` block, and the command references `$NAME`. A shell variable's **value** is not re-expanded, so the secret reaches Ansible byte for byte whatever characters it contains.

No behaviour change for any secret that was already correct.

## After merge

`update-env` → redeploy backend → the app finally gets the real password. Note SMTP still needs the right host: the domain is on-premise Exchange (`mail.innopolis.ru`, AUTH `GSSAPI NTLM LOGIN`), not `smtp.gmail.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)